### PR TITLE
Fix misc regressions introduced while reworking how we compile to Ruby

### DIFF
--- a/lib/rbexy.rb
+++ b/lib/rbexy.rb
@@ -32,7 +32,6 @@ module Rbexy
     def compile(template, element_resolver = Rbexy.configuration.element_resolver)
       tokens = Lexer.new(template, element_resolver).tokenize
       root = Parser.new(tokens).parse
-      binding.pry
       root.precompile.compile
     end
 

--- a/lib/rbexy.rb
+++ b/lib/rbexy.rb
@@ -32,6 +32,7 @@ module Rbexy
     def compile(template, element_resolver = Rbexy.configuration.element_resolver)
       tokens = Lexer.new(template, element_resolver).tokenize
       root = Parser.new(tokens).parse
+      binding.pry
       root.precompile.compile
     end
 

--- a/lib/rbexy/lexer.rb
+++ b/lib/rbexy/lexer.rb
@@ -59,7 +59,7 @@ module Rbexy
           elsif scanner.scan(Patterns.open_expression)
             open_expression
           elsif scanner.scan(Patterns.comment)
-            tokens << [:SILENT_NEWLINE]
+            tokens << [:NEWLINE]
           elsif scanner.check(Patterns.text_content)
             stack.push(:default_text)
           else
@@ -74,7 +74,7 @@ module Rbexy
           elsif scanner.scan(Patterns.open_expression)
             open_expression
           elsif scanner.scan(Patterns.comment)
-            tokens << [:SILENT_NEWLINE]
+            tokens << [:NEWLINE]
           elsif scanner.check(Patterns.text_content)
             stack.push(:default_text)
           else
@@ -165,7 +165,7 @@ module Rbexy
           elsif scanner.scan(Patterns.tag_name)
             tokens << [:TAG_DETAILS, tag_details(scanner.matched)]
           elsif scanner.scan(Patterns.whitespace)
-            scanner.matched.count("\n").times { tokens << [:SILENT_NEWLINE] }
+            scanner.matched.count("\n").times { tokens << [:NEWLINE] }
             tokens << [:OPEN_ATTRS]
             stack.push(:tag_attrs)
           else
@@ -182,7 +182,7 @@ module Rbexy
           end
         when :tag_attrs
           if scanner.scan(Patterns.whitespace)
-            scanner.matched.count("\n").times { tokens << [:SILENT_NEWLINE] }
+            scanner.matched.count("\n").times { tokens << [:NEWLINE] }
           elsif scanner.check(Patterns.close_tag)
             tokens << [:CLOSE_ATTRS]
             stack.pop
@@ -205,7 +205,7 @@ module Rbexy
             open_expression
           elsif scanner.scan(Patterns.whitespace) || scanner.check(Patterns.close_tag)
             tokens << [:CLOSE_ATTR_VALUE]
-            scanner.matched.count("\n").times { tokens << [:SILENT_NEWLINE] }
+            scanner.matched.count("\n").times { tokens << [:NEWLINE] }
             stack.pop
           else
             raise SyntaxError, self

--- a/lib/rbexy/nodes.rb
+++ b/lib/rbexy/nodes.rb
@@ -13,7 +13,7 @@ module Rbexy
     autoload :XMLAttr, "rbexy/nodes/xml_attr"
     autoload :HTMLAttr, "rbexy/nodes/html_attr"
     autoload :ComponentProp, "rbexy/nodes/component_prop"
-    autoload :SilentNewline, "rbexy/nodes/silent_newline"
+    autoload :Newline, "rbexy/nodes/newline"
     autoload :Declaration, "rbexy/nodes/declaration"
   end
 end

--- a/lib/rbexy/nodes/abstract_node.rb
+++ b/lib/rbexy/nodes/abstract_node.rb
@@ -18,7 +18,9 @@ module Rbexy
         curr_raw = nil
 
         nodes.each do |node|
-          if node.is_a?(Raw)
+          if node.is_a?(SilentNewline) && curr_raw
+            curr_raw.merge(Raw.new("\n"))
+          elsif node.is_a?(Raw)
             if !curr_raw
               curr_raw ||= Raw.new("")
               compacted << curr_raw

--- a/lib/rbexy/nodes/abstract_node.rb
+++ b/lib/rbexy/nodes/abstract_node.rb
@@ -18,7 +18,7 @@ module Rbexy
         curr_raw = nil
 
         nodes.each do |node|
-          if node.is_a?(SilentNewline) && curr_raw
+          if node.is_a?(Newline) && curr_raw
             curr_raw.merge(Raw.new("\n"))
           elsif node.is_a?(Raw)
             if !curr_raw

--- a/lib/rbexy/nodes/component_element.rb
+++ b/lib/rbexy/nodes/component_element.rb
@@ -1,6 +1,16 @@
 module Rbexy
   module Nodes
     class ComponentElement < AbstractElement
+      attr_reader :template
+
+      OUTPUT = "@output_buffer.safe_concat(%s);"
+      EXPR_STRING = "%s.html_safe"
+
+      def initialize(*args, template: OUTPUT)
+        super(*args)
+        @template = template
+      end
+
       def precompile
         [ComponentElement.new(name, precompile_members, precompile_children)]
       end
@@ -19,7 +29,7 @@ module Rbexy
           tag = "(rbexy_context.push({});#{tag}.tap{rbexy_context.pop})"
         end
 
-        "@output_buffer.safe_concat(#{tag});"
+        template % tag
       end
 
       def compile_members
@@ -38,7 +48,17 @@ module Rbexy
       private
 
       def precompile_members
-        members.map(&:precompile).flatten
+        members.map do |node|
+          if node.is_a? ExpressionGroup
+            ExpressionGroup.new(
+              node.statements,
+              inner_template: ExpressionGroup::SUB_EXPR,
+              outer_template: ExpressionGroup::SUB_EXPR
+            )
+          else
+            node
+          end
+        end.map(&:precompile).flatten
       end
 
       def precompile_children

--- a/lib/rbexy/nodes/component_element.rb
+++ b/lib/rbexy/nodes/component_element.rb
@@ -37,7 +37,7 @@ module Rbexy
           case member
           when ExpressionGroup
             result << "**#{member.compile},"
-          when SilentNewline
+          when Newline
             result << member.compile
           else
             result << "#{member.compile},"

--- a/lib/rbexy/nodes/expression_group.rb
+++ b/lib/rbexy/nodes/expression_group.rb
@@ -8,8 +8,8 @@ module Rbexy
 
       OUTPUT_UNSAFE = "@output_buffer.concat(Rbexy::Runtime.expr_out(%s));"
       OUTPUT_SAFE = "@output_buffer.safe_concat(Rbexy::Runtime.expr_out(%s));"
-      SUB_EXPR = "Rbexy::Runtime.expr_out(%s)"
-      SUB_EXPR_EXPLICIT_TO_S = "(%s).to_s"
+      SUB_EXPR = "%s"
+      SUB_EXPR_OUT = "Rbexy::Runtime.expr_out(%s)"
 
       def initialize(statements, outer_template: OUTPUT_UNSAFE, inner_template: "%s")
         @statements = statements
@@ -42,8 +42,10 @@ module Rbexy
             node
           end
         end.map_type_when_neighboring_type(ExpressionGroup, Raw) do |node|
-          ExpressionGroup.new(node.statements, outer_template: SUB_EXPR_EXPLICIT_TO_S, inner_template: node.inner_template)
+          ExpressionGroup.new(node.statements, outer_template: SUB_EXPR_OUT, inner_template: node.inner_template)
         end.insert_between_types(ExpressionGroup, Raw) do
+          Expression.new("+")
+        end.insert_between_types(ComponentElement, Raw) do
           Expression.new("+")
         end
       end

--- a/lib/rbexy/nodes/expression_group.rb
+++ b/lib/rbexy/nodes/expression_group.rb
@@ -34,6 +34,8 @@ module Rbexy
           case node
           when Raw
             Raw.new(node.content, template: Raw::EXPR_STRING)
+          when ComponentElement
+            ComponentElement.new(node.name, node.members, node.children, template: ComponentElement::EXPR_STRING)
           when ExpressionGroup
             ExpressionGroup.new(node.statements, outer_template: SUB_EXPR, inner_template: node.inner_template)
           else

--- a/lib/rbexy/nodes/expression_group.rb
+++ b/lib/rbexy/nodes/expression_group.rb
@@ -8,7 +8,7 @@ module Rbexy
 
       OUTPUT_UNSAFE = "@output_buffer.concat(Rbexy::Runtime.expr_out(%s));"
       OUTPUT_SAFE = "@output_buffer.safe_concat(Rbexy::Runtime.expr_out(%s));"
-      SUB_EXPR = "%s"
+      SUB_EXPR = "Rbexy::Runtime.expr_out(%s)"
       SUB_EXPR_EXPLICIT_TO_S = "(%s).to_s"
 
       def initialize(statements, outer_template: OUTPUT_UNSAFE, inner_template: "%s")

--- a/lib/rbexy/nodes/html_element.rb
+++ b/lib/rbexy/nodes/html_element.rb
@@ -6,14 +6,12 @@ module Rbexy
       def precompile
         nodes = []
 
-        if children.length > 0
+        if void? && children.length == 0
+          nodes.concat(precompile_open_tag)
+        else
           nodes.concat(precompile_open_tag)
           nodes.concat(children.map(&:precompile).flatten)
           nodes << Raw.new("</#{name}>")
-        elsif void?
-          nodes.concat(precompile_open_tag)
-        else
-          nodes.concat(precompile_open_tag(close: true))
         end
 
         nodes
@@ -25,10 +23,10 @@ module Rbexy
         KNOWN_VOID_ELEMENTS.include?(name)
       end
 
-      def precompile_open_tag(close: false)
+      def precompile_open_tag
         nodes = [Raw.new("<#{name}")]
         nodes.concat(precompile_members)
-        nodes << Raw.new(close ? " />" : ">")
+        nodes << Raw.new(">")
         nodes
       end
 

--- a/lib/rbexy/nodes/newline.rb
+++ b/lib/rbexy/nodes/newline.rb
@@ -1,6 +1,6 @@
 module Rbexy
   module Nodes
-    class SilentNewline < AbstractNode
+    class Newline < AbstractNode
       def compile
         "\n"
       end

--- a/lib/rbexy/parser.rb
+++ b/lib/rbexy/parser.rb
@@ -26,7 +26,7 @@ module Rbexy
     end
 
     def parse_token
-      parse_text || parse_silent_newline || parse_expression || parse_tag || parse_declaration
+      parse_text || parse_newline || parse_expression || parse_tag || parse_declaration
     end
 
     def parse_text
@@ -64,7 +64,7 @@ module Rbexy
       attr_class = details[:type] == :component ? Nodes::ComponentProp : Nodes::HTMLAttr
 
       members = []
-      members.concat(take_all(:SILENT_NEWLINE).map { Nodes::SilentNewline.new })
+      members.concat(take_all(:NEWLINE).map { Nodes::Newline.new })
       members.concat(parse_attrs(attr_class))
 
       take!(:CLOSE_TAG_DEF)
@@ -85,7 +85,7 @@ module Rbexy
 
       eventually!(:CLOSE_ATTRS)
       until take(:CLOSE_ATTRS)
-        attrs << (parse_splat_attr || parse_silent_newline || parse_attr(attr_class))
+        attrs << (parse_splat_attr || parse_newline || parse_attr(attr_class))
       end
 
       attrs
@@ -100,9 +100,9 @@ module Rbexy
       expression
     end
 
-    def parse_silent_newline
-      return unless take(:SILENT_NEWLINE)
-      Nodes::SilentNewline.new
+    def parse_newline
+      return unless take(:NEWLINE)
+      Nodes::Newline.new
     end
 
     def parse_attr(attr_class)

--- a/spec/lib/rbexy/lexer_spec.rb
+++ b/spec/lib/rbexy/lexer_spec.rb
@@ -570,7 +570,7 @@ RBX
     expect(subject.tokenize).to eq [
       [:OPEN_TAG_DEF],
       [:TAG_DETAILS, { name: "div", type: :html }],
-      [:SILENT_NEWLINE],
+      [:NEWLINE],
       [:OPEN_ATTRS],
       [:ATTR_NAME, "foo"],
       [:OPEN_ATTR_VALUE],
@@ -601,7 +601,7 @@ RBX
       [:OPEN_ATTR_VALUE],
       [:TEXT, "bar"],
       [:CLOSE_ATTR_VALUE],
-      [:SILENT_NEWLINE],
+      [:NEWLINE],
       [:ATTR_NAME, "baz"],
       [:OPEN_ATTR_VALUE],
       [:TEXT, "bip"],
@@ -627,18 +627,18 @@ RBX
     expect(subject.tokenize).to eq [
       [:OPEN_TAG_DEF],
       [:TAG_DETAILS, { name: "input", type: :html }],
-      [:SILENT_NEWLINE],
+      [:NEWLINE],
       [:OPEN_ATTRS],
       [:ATTR_NAME, "foo"],
       [:OPEN_ATTR_VALUE],
       [:TEXT, "bar"],
       [:CLOSE_ATTR_VALUE],
-      [:SILENT_NEWLINE],
+      [:NEWLINE],
       [:ATTR_NAME, "baz"],
       [:OPEN_ATTR_VALUE],
       [:TEXT, "bip"],
       [:CLOSE_ATTR_VALUE],
-      [:SILENT_NEWLINE],
+      [:NEWLINE],
       [:CLOSE_ATTRS],
       [:CLOSE_TAG_DEF],
       [:OPEN_TAG_END],
@@ -752,7 +752,7 @@ RBX
   end
 
   context "comments" do
-    it "tokenizes lines starting with # as SILENT_NEWLINE" do
+    it "tokenizes lines starting with # as NEWLINE" do
       template_string = <<-RBX.strip_heredoc.strip
         Hello
         # some comment
@@ -762,12 +762,12 @@ RBX
       subject = Rbexy::Lexer.new(Rbexy::Template.new(template_string), Rbexy::ComponentResolver.new)
       expect(subject.tokenize).to eq [
         [:TEXT, "Hello\n"],
-        [:SILENT_NEWLINE],
+        [:NEWLINE],
         [:TEXT, "world"],
       ]
     end
 
-    it "tokenizes the first line if starting with # as SILENT_NEWLINE" do
+    it "tokenizes the first line if starting with # as NEWLINE" do
       template_string = <<-RBX.strip_heredoc.strip
         # some comment
         Hello world
@@ -775,12 +775,12 @@ RBX
 
       subject = Rbexy::Lexer.new(Rbexy::Template.new(template_string), Rbexy::ComponentResolver.new)
       expect(subject.tokenize).to eq [
-        [:SILENT_NEWLINE],
+        [:NEWLINE],
         [:TEXT, "Hello world"],
       ]
     end
 
-    it "tokenizes the last line if starting with # as SILENT_NEWLINE" do
+    it "tokenizes the last line if starting with # as NEWLINE" do
       template_string = <<-RBX.strip_heredoc.strip
       Hello world
       # some comment
@@ -789,7 +789,7 @@ RBX
       subject = Rbexy::Lexer.new(Rbexy::Template.new(template_string), Rbexy::ComponentResolver.new)
       expect(subject.tokenize).to eq [
         [:TEXT, "Hello world\n"],
-        [:SILENT_NEWLINE],
+        [:NEWLINE],
       ]
     end
 
@@ -803,7 +803,7 @@ RBX
       subject = Rbexy::Lexer.new(Rbexy::Template.new(template_string), Rbexy::ComponentResolver.new)
       expect(subject.tokenize).to eq [
         [:TEXT, "Hello world\n"],
-        [:SILENT_NEWLINE],
+        [:NEWLINE],
         [:TEXT, "Another text"]
       ]
     end
@@ -821,7 +821,7 @@ RBX
         [:TAG_DETAILS, { name: "div", type: :html }],
         [:CLOSE_TAG_DEF],
         [:TEXT, "\n"],
-        [:SILENT_NEWLINE],
+        [:NEWLINE],
         [:OPEN_TAG_END],
         [:TAG_NAME, "div"],
         [:CLOSE_TAG_END],

--- a/spec/rbexy_spec.rb
+++ b/spec/rbexy_spec.rb
@@ -463,7 +463,7 @@ RSpec.describe Rbexy do
       expect(result).to eq expected
     end
 
-    it "allows loops within sub-expressions", focus: true do
+    it "allows loops within sub-expressions" do
       template_string = <<-RBX.strip_heredoc.strip
         {true && <ul>
           {["Hello", "world"].map { |v| <li>{v}</li> }}

--- a/spec/rbexy_spec.rb
+++ b/spec/rbexy_spec.rb
@@ -463,6 +463,51 @@ RSpec.describe Rbexy do
       expect(result).to eq expected
     end
 
+    it "allows loops within sub-expressions", focus: true do
+      template_string = <<-RBX.strip_heredoc.strip
+        {true && <ul>
+          {["Hello", "world"].map { |v| <li>{v}</li> }}
+        </ul>}
+      RBX
+
+      result = Rbexy.evaluate(template_string, Rbexy::Runtime.new)
+
+      expected = <<-OUTPUT.strip_heredoc.strip
+        <ul>
+          <li>Hello</li><li>world</li>
+        </ul>
+      OUTPUT
+
+      expect(result).to eq expected
+    end
+
+    it "allows html>custom hierarchies within loops" do
+      class ButtonComponent
+        def initialize(*)
+        end
+
+        def render
+          "<button></button>"
+        end
+      end
+
+      template_string = <<-RBX.strip_heredoc.strip
+        {<ul>
+          {["Hello", "world"].map { |v| <li>{v} <Button /></li> }}
+        </ul>}
+      RBX
+
+      result = Rbexy.evaluate(template_string, Rbexy::Runtime.new)
+
+      expected = <<-OUTPUT.strip_heredoc.strip
+        <ul>
+          <li>Hello <button></button></li><li>world <button></button></li>
+        </ul>
+      OUTPUT
+
+      expect(result).to eq expected
+    end
+
     it "explicitly coerces expression values in attributes to strings" do
       expect(Rbexy.evaluate("{[1, 2].map { <div id={BigDecimal('10')}></div> }}", Rbexy::Runtime.new))
         .to eq '<div id="10.0"></div><div id="10.0"></div>'


### PR DESCRIPTION
* Fix bug where SilentNewlines within sub-expression tags caused multiline tags to only output the last line
* Fix invalid HTML bug: do not self-close childless tags that are not valid void tags
* Fix bug preventing splat attributes on custom components
* Fix tags within boolean expressions
* Fix misc bugs related to expressions within expressions and certain html->component hierarchies therein
