### PR TITLE
Add OR operator to lexer

### DIFF
--- a/lib/rbexy/lexer.rb
+++ b/lib/rbexy/lexer.rb
@@ -29,7 +29,7 @@ module Rbexy
       single_quote: /'/,
       double_quoted_text_content: /[^"]+/,
       single_quoted_text_content: /[^']+/,
-      expression_internal_tag_prefixes: /(\s+(&&|\?|:|do|do\s*\|[^\|]+\||{|{\s*\|[^\|]+\|)\s+\z|\A\s*\z)/,
+      expression_internal_tag_prefixes: /(\s+(&&|\|\||\?|:|do|do\s*\|[^\|]+\||{|{\s*\|[^\|]+\|)\s+\z|\A\s*\z)/,
       declaration: /<![^>]*>/
     )
 

--- a/spec/lib/rbexy/lexer_spec.rb
+++ b/spec/lib/rbexy/lexer_spec.rb
@@ -360,6 +360,23 @@ RSpec.describe Rbexy::Lexer do
     ]
   end
 
+  it "tokenizes tags within a boolean expression including an OR operator" do
+    subject = Rbexy::Lexer.new(Rbexy::Template.new("{true || <p>Yes</p>}"), Rbexy::ComponentResolver.new)
+    expect(subject.tokenize).to eq [
+      [:OPEN_EXPRESSION],
+      [:EXPRESSION_BODY, "true || "],
+      [:OPEN_TAG_DEF],
+      [:TAG_DETAILS, { name: "p", type: :html }],
+      [:CLOSE_TAG_DEF],
+      [:TEXT, "Yes"],
+      [:OPEN_TAG_END],
+      [:TAG_NAME, "p"],
+      [:CLOSE_TAG_END],
+      [:EXPRESSION_BODY, ""],
+      [:CLOSE_EXPRESSION],
+    ]
+  end
+
   it "tokenizes tags within a do..end block" do
     template = <<-RBX.strip
 {3.times do

--- a/spec/rbexy_spec.rb
+++ b/spec/rbexy_spec.rb
@@ -43,6 +43,22 @@ RSpec.describe Rbexy do
     expect(result).to eq expected
   end
 
+  it "supports the or operator" do
+    template_string = <<-RBX.strip_heredoc.strip
+      {true && <p>Is true</p> || <p>Is false</p>}
+      {false && <p>Is true</p> || <p>Is false</p>}
+    RBX
+
+    result = Rbexy.evaluate(template_string, Rbexy::Runtime.new)
+
+    expected = <<-OUTPUT.strip_heredoc.strip
+      <p>Is true</p>
+      <p>Is false</p>
+    OUTPUT
+
+    expect(result).to eq expected
+  end
+
   it "handles html with expression attributes" do
     template_string = <<-RBX.strip_heredoc.strip
       <h1 class={true && "my-class"} id={false ? "is-true" : "is-false"}>Hello world</h1>


### PR DESCRIPTION
I was using rbexy when I discovered something strange, all the OR operators that I added were failing, digging a little bit I discovered that rbexy does not support this operator which I was surprised since it does support the AND operator.
I consider it a good idea since it improves consistency and if we take advantage of ruby's short circuit property we can do interesting things like:
`{false && <p>Is true</p> || <p>Is false</p>}`
This is my first pull request to an open-source project so any guidance is
appreciated :)