### PR TITLE
Debuggers in templates

### DIFF
--- a/spec/compiler_spec.rb
+++ b/spec/compiler_spec.rb
@@ -1,0 +1,25 @@
+require "active_support/core_ext/string/strip"
+
+RSpec.describe "rbx->ruby integration tests" do
+  describe "debuggers" do
+    it "compiles them to quiet output and adds a newline so the binding isn't placed into the output_buffer call" do
+      template_string = <<-RBX.strip_heredoc
+        {binding.pry}
+      RBX
+
+      result = Rbexy.compile(Rbexy::Template.new(template_string))
+      expect(result).to eq "binding.pry\n@output_buffer.safe_concat('\n'.freeze);@output_buffer.to_s"
+    end
+
+    it "works for debuggers inside html tags as well" do
+      template_string = <<-RBX.strip_heredoc
+        <h1>
+          {binding.pry}
+        </h1>
+      RBX
+
+      result = Rbexy.compile(Rbexy::Template.new(template_string))
+      expect(result).to eq "@output_buffer.safe_concat('<h1>\n  '.freeze);binding.pry\n@output_buffer.safe_concat('\n</h1>\n'.freeze);@output_buffer.to_s"
+    end
+  end
+end

--- a/spec/lib/rbexy/nodes/expression_group_spec.rb
+++ b/spec/lib/rbexy/nodes/expression_group_spec.rb
@@ -1,0 +1,21 @@
+RSpec.describe Rbexy::Nodes::ExpressionGroup do
+  describe "precompile->compile" do
+    it "doesn't try to output a debugger and adds a newline to ensure binding is in the right place" do
+      subject = described_class.new([Rbexy::Nodes::Expression.new("debugger")])
+      result = subject.precompile.map(&:compile).join
+      expect(result).to eq "debugger\n"
+    end
+
+    it "doesn't try to output a binding.pry and adds a newline to ensure binding is in the right place" do
+      subject = described_class.new([Rbexy::Nodes::Expression.new("binding.pry")])
+      result = subject.precompile.map(&:compile).join
+      expect(result).to eq "binding.pry\n"
+    end
+
+    it "doesn't care about leading or trailing whitespace" do
+      subject = described_class.new([Rbexy::Nodes::Expression.new("   binding.pry   ")])
+      result = subject.precompile.map(&:compile).join
+      expect(result).to eq "   binding.pry   \n"
+    end
+  end
+end


### PR DESCRIPTION
Special-case debuggers to ensure bindings land the user where they would expect in the call stack. Closes #66