### PR TITLE
Fix kwargs on view context methods

### DIFF
--- a/lib/rbexy/component.rb
+++ b/lib/rbexy/component.rb
@@ -86,8 +86,8 @@ module Rbexy
       raise error
     end
 
-    def method_missing(meth, *args, &block)
-      view_context.send(meth, *args, &block)
+    def method_missing(meth, *args, **kwargs, &block)
+      view_context.send(meth, *args, **kwargs, &block)
     end
 
     def respond_to_missing?(method_name, include_all)

--- a/rbexy.gemspec
+++ b/rbexy.gemspec
@@ -9,7 +9,7 @@ Gem::Specification.new do |spec|
   spec.summary       = "A Ruby template language inspired by JSX"
   spec.homepage      = "https://github.com/patbenatar/rbexy"
   spec.license       = "MIT"
-  spec.required_ruby_version = Gem::Requirement.new(">= 2.3.0")
+  spec.required_ruby_version = Gem::Requirement.new(">= 2.7.0")
 
   spec.metadata["allowed_push_host"] = "https://rubygems.org"
 

--- a/spec/dummy/app/components/method_missing_component.rb
+++ b/spec/dummy/app/components/method_missing_component.rb
@@ -1,0 +1,5 @@
+class MethodMissingComponent < Rbexy::Component
+  def method_relying_on_method_missing
+    method_with_keywords(1, b: 2, c: 3).join(" ")
+  end
+end

--- a/spec/dummy/app/components/method_missing_component.rbx
+++ b/spec/dummy/app/components/method_missing_component.rbx
@@ -1,0 +1,1 @@
+<h1>{method_relying_on_method_missing}</h1>

--- a/spec/dummy/app/helpers/application_helper.rb
+++ b/spec/dummy/app/helpers/application_helper.rb
@@ -1,2 +1,5 @@
 module ApplicationHelper
+  def method_with_keywords(a, b:, c: 2)
+    [a, b, c]
+  end
 end

--- a/spec/integration/component_spec.rb
+++ b/spec/integration/component_spec.rb
@@ -29,6 +29,11 @@ RSpec.describe ApplicationController, type: :controller do
       .to have_tag("h1", text: "ivar value")
   end
 
+  it "correctly uses methods from the context with keywords" do
+    expect(MethodMissingComponent.new(view_context).render_in)
+      .to have_tag("h1", text: "1 2 3")
+  end
+
   it "passes props to #setup" do
     expect(PropsComponent.new(view_context, my_prop: "prop value").render_in)
       .to have_tag("h1", text: "prop value after setup")


### PR DESCRIPTION
I've added a minimum Ruby version bump to 2.7.0, but if you'd like to support < 2.7 I can make it work.