### PR TITLE
Simplify Rails Integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,12 +63,6 @@ gem "rbexy"
 
 _From 1.0 onward, we only support Rails 6. If you're using Rails 5, use the 0.x releases._
 
-In `config/application.rb`:
-
-```ruby
-require "rbexy/rails/engine"
-```
-
 _Not using Rails? See "Usage outside of Rails" below._
 
 Create your first component at `app/components/hello_world_component.rb`:

--- a/lib/rbexy.rb
+++ b/lib/rbexy.rb
@@ -2,10 +2,9 @@ require "rbexy/version"
 require "active_support/inflector"
 require "active_support/concern"
 require "active_support/core_ext/enumerable"
-require "action_view/helpers/output_safety_helper"
-require "action_view/helpers/capture_helper"
-require "action_view/helpers/tag_helper"
-require "action_view/context"
+require "action_view"
+
+require "rbexy/rails/engine" if defined?(::Rails)
 
 module Rbexy
   autoload :Lexer, "rbexy/lexer"

--- a/lib/rbexy/component.rb
+++ b/lib/rbexy/component.rb
@@ -1,4 +1,3 @@
-require "action_view"
 require "active_support/core_ext/class/attribute"
 
 module Rbexy

--- a/spec/rbexy_spec.rb
+++ b/spec/rbexy_spec.rb
@@ -1,8 +1,6 @@
 require "active_support/core_ext/string/strip"
 require "active_support/all"
-require "action_view/helpers"
-require "action_view/context"
-require "action_view/buffers"
+require "action_view"
 
 RSpec.describe Rbexy do
   it "has a version number" do


### PR DESCRIPTION
> Closes #100

This resolves an issue which currently happens, attempting to load rbexy into a fresh rails application. You get odd constant undefined errors due to trying to find constants in the wrong module.

This was simplified by including _all_ of `action_view`. We depend on quite a few things from ActionView. Including the main module merely defines autoloads for the library, but does not _include_ anything until requested. This seems to ensure things get loaded in whatever order they need to get loaded in. (apparently the `require`'s within the rails code is... for show?)

This also simplifies Rails integration by auto-loading the engine if we're in the Rails environment. Rails apps explicitly require rails before loading bundled gems (in `application.rb`), there for we're guaranteed it is defined.